### PR TITLE
Updating rating -> rating score for versioned

### DIFF
--- a/code/Admin/RatingAdmin.php
+++ b/code/Admin/RatingAdmin.php
@@ -2,12 +2,21 @@
 
 namespace DNADesign\Elemental\Admins;
 
+use Colymba\BulkManager\BulkAction\ArchiveHandler;
+use Colymba\BulkManager\BulkAction\DeleteHandler;
 use SilverStripe\Admin\ModelAdmin;
-use DNADesign\Elemental\Models\Rating;
-use DNADesign\Elemental\Models\ElementRatingBlock;
+use SilverStripe\Security\Security;
 use Colymba\BulkManager\BulkManager;
-use Colymba\BulkManager\BulkAction\UnlinkHandler;
+use SilverStripe\Security\Permission;
+use DNADesign\Elemental\Models\Rating;
 use Colymba\BulkManager\BulkAction\EditHandler;
+use Colymba\BulkManager\BulkAction\UnlinkHandler;
+use DNADesign\Elemental\Models\ElementRatingBlock;
+use SilverStripe\Versioned\GridFieldArchiveAction;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
+use SilverStripe\Forms\GridField\GridFieldDeleteAction;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldImportButton;
 
 class RatingAdmin extends ModelAdmin
 {
@@ -28,13 +37,18 @@ class RatingAdmin extends ModelAdmin
 
         $field = $form->Fields()->dataFieldByName($this->sanitiseClassName($this->modelClass));
         $config = $field->getConfig();
+        $member = Security::getCurrentUser();
 
         if ($this->modelClass === Rating::class) {
-            // Add bulk option
-            $manager = new BulkManager();
-            $manager->removeBulkAction(EditHandler::class);
-            $manager->removeBulkAction(UnlinkHandler::class);
-            $config->addComponent($manager);
+            if (Permission::check('ARCHIVE_RATING', 'any', $member)) {
+                // Add bulk option
+                $manager = BulkManager::create();
+                $manager->removeBulkAction(EditHandler::class);
+                $manager->removeBulkAction(UnlinkHandler::class);
+                $manager->removeBulkAction(DeleteHandler::class);
+                $manager->addBulkAction(ArchiveHandler::class);
+                $config->addComponent($manager);
+            }
         }
 
         if ($this->modelClass === ElementRatingBlock::class) {

--- a/code/Model/Rating.php
+++ b/code/Model/Rating.php
@@ -6,6 +6,7 @@ use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Permission;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\CMS\Model\SiteTree;
 
 class Rating extends DataObject implements PermissionProvider
@@ -35,6 +36,10 @@ class Rating extends DataObject implements PermissionProvider
         'Tags' => 'Tags',
         'URL' => 'Rated URL',
         'Created' => 'Created'
+    ];
+
+    private static $extensions = [
+        Versioned::class
     ];
 
     private static $default_sort = 'ID DESC';
@@ -138,8 +143,8 @@ class Rating extends DataObject implements PermissionProvider
                 'name' => 'View Ratings',
                 'category' => 'Ratings'
             ],
-            'DELETE_RATING' => [
-                'name' => 'Delete Ratings',
+            'ARCHIVE_RATING' => [
+                'name' => 'Archive Ratings',
                 'category' => 'Ratings'
             ]
         ];
@@ -157,7 +162,7 @@ class Rating extends DataObject implements PermissionProvider
 
     public function canDelete($member = null)
     {
-        return Permission::check('DELETE_RATING');
+        return false;
     }
 
     public function canView($member = null)


### PR DESCRIPTION
- Makes various updates around versioning, archiving and adding permissions in for ratings.
- Needed to updating Rating.Rating to Rating.RatingScore as it breaks with versioning if we leaving it as Rating.Rating
- Removes the ability to delete a rating
- Changes permission for Delete rating to archive rating